### PR TITLE
[#1] github-issue-1-ruumu-ni-urlwo

### DIFF
--- a/packages/frontend/src/app/app.tsx
+++ b/packages/frontend/src/app/app.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import HomeRoute from './routes/home';
 import RoomRoute from './routes/room';
+import JoinRoute from './routes/join';
 
 export function App() {
   return (
@@ -8,6 +9,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<HomeRoute />} />
         <Route path="/room/:roomId" element={<RoomRoute />} />
+        <Route path="/join/:roomId" element={<JoinRoute />} />
       </Routes>
     </BrowserRouter>
   );

--- a/packages/frontend/src/app/routes/join.tsx
+++ b/packages/frontend/src/app/routes/join.tsx
@@ -1,0 +1,21 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useCallback } from 'react';
+import { JoinView } from '../../features/join/components/join-view';
+
+export default function JoinRoute() {
+  const { roomId } = useParams<{ roomId: string }>();
+  const navigate = useNavigate();
+
+  if (!roomId) {
+    throw new Error('roomId is required');
+  }
+
+  const handleSubmit = useCallback(
+    (data: { userName: string }) => {
+      navigate(`/room/${roomId}`, { state: { userName: data.userName, mode: 'join' } });
+    },
+    [navigate, roomId],
+  );
+
+  return <JoinView roomId={roomId} onSubmit={handleSubmit} />;
+}

--- a/packages/frontend/src/features/join/components/__tests__/join-view.test.tsx
+++ b/packages/frontend/src/features/join/components/__tests__/join-view.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { JoinView } from '../join-view';
+
+describe('JoinView', () => {
+  it('should render user name input and join button', () => {
+    // Given
+    const onSubmit = vi.fn();
+
+    // When
+    render(<JoinView roomId="room-abc" onSubmit={onSubmit} />);
+
+    // Then
+    expect(screen.getByLabelText(/ユーザー名/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /参加/ })).toBeInTheDocument();
+  });
+
+  it('should display the roomId so users know which room they are joining', () => {
+    // Given
+    const onSubmit = vi.fn();
+
+    // When
+    render(<JoinView roomId="room-abc" onSubmit={onSubmit} />);
+
+    // Then
+    expect(screen.getByText(/room-abc/)).toBeInTheDocument();
+  });
+
+  it('should call onSubmit with userName when form is submitted', async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<JoinView roomId="room-abc" onSubmit={onSubmit} />);
+
+    // When
+    await user.type(screen.getByLabelText(/ユーザー名/), 'Alice');
+    await user.click(screen.getByRole('button', { name: /参加/ }));
+
+    // Then
+    expect(onSubmit).toHaveBeenCalledWith({ userName: 'Alice' });
+  });
+
+  it('should not submit when userName is empty', async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<JoinView roomId="room-abc" onSubmit={onSubmit} />);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /参加/ }));
+
+    // Then
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should trim whitespace from userName', async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<JoinView roomId="room-abc" onSubmit={onSubmit} />);
+
+    // When
+    await user.type(screen.getByLabelText(/ユーザー名/), '  Alice  ');
+    await user.click(screen.getByRole('button', { name: /参加/ }));
+
+    // Then
+    expect(onSubmit).toHaveBeenCalledWith({ userName: 'Alice' });
+  });
+
+  it('should not render roomId input field', () => {
+    // Given
+    const onSubmit = vi.fn();
+
+    // When
+    render(<JoinView roomId="room-abc" onSubmit={onSubmit} />);
+
+    // Then
+    expect(screen.queryByLabelText(/ルームID/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/features/join/components/join-view.tsx
+++ b/packages/frontend/src/features/join/components/join-view.tsx
@@ -1,0 +1,46 @@
+import { type FormEvent, useState } from 'react';
+
+interface JoinViewProps {
+  roomId: string;
+  onSubmit: (data: { userName: string }) => void;
+}
+
+export function JoinView({ roomId, onSubmit }: JoinViewProps) {
+  const [userName, setUserName] = useState('');
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const trimmed = userName.trim();
+    if (!trimmed) return;
+    onSubmit({ userName: trimmed });
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-8 space-y-6">
+      <h1 className="text-2xl font-bold text-center">ルームに参加</h1>
+      <p className="text-center text-gray-600">
+        ルーム: <span>{roomId}</span>
+      </p>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="join-userName" className="block text-sm font-medium text-gray-700">
+            ユーザー名
+          </label>
+          <input
+            id="join-userName"
+            type="text"
+            value={userName}
+            onChange={(e) => setUserName(e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm"
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700"
+        >
+          参加
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/packages/frontend/src/features/room/components/__tests__/invite-link.test.tsx
+++ b/packages/frontend/src/features/room/components/__tests__/invite-link.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InviteLink } from '../invite-link';
+
+describe('InviteLink', () => {
+  it('should display the invite URL containing the roomId', () => {
+    // Given / When
+    render(<InviteLink roomId="room-abc" />);
+
+    // Then
+    expect(screen.getByText(/\/join\/room-abc/)).toBeInTheDocument();
+  });
+
+  it('should render a copy button', () => {
+    // Given / When
+    render(<InviteLink roomId="room-abc" />);
+
+    // Then
+    expect(screen.getByRole('button', { name: /コピー/ })).toBeInTheDocument();
+  });
+
+  it('should copy the invite URL to clipboard when copy button is clicked', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<InviteLink roomId="room-abc" />);
+    // userEvent.setup() がclipboardポリフィルを提供するため、setup後にspyする
+    const writeTextSpy = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue(undefined);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /コピー/ }));
+
+    // Then
+    expect(writeTextSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/join/room-abc'),
+    );
+  });
+
+  it('should show feedback after successful copy', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<InviteLink roomId="room-abc" />);
+    vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /コピー/ }));
+
+    // Then
+    expect(screen.getByText(/コピーしました/)).toBeInTheDocument();
+  });
+
+  it('should show error feedback when clipboard write fails', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<InviteLink roomId="room-abc" />);
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(
+      new Error('denied'),
+    );
+
+    // When
+    await user.click(screen.getByRole('button', { name: /コピー/ }));
+
+    // Then
+    expect(screen.getByText(/コピーに失敗しました/)).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/features/room/components/invite-link.tsx
+++ b/packages/frontend/src/features/room/components/invite-link.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+interface InviteLinkProps {
+  roomId: string;
+}
+
+export function InviteLink({ roomId }: InviteLinkProps) {
+  const [feedback, setFeedback] = useState<'copied' | 'error' | null>(null);
+  const url = `${window.location.origin}/join/${roomId}`;
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setFeedback('copied');
+    } catch {
+      setFeedback('error');
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="text-gray-600 truncate">{url}</span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="px-3 py-1 bg-gray-200 rounded hover:bg-gray-300 text-gray-700 whitespace-nowrap"
+      >
+        コピー
+      </button>
+      {feedback === 'copied' && (
+        <span className="text-green-600 whitespace-nowrap">コピーしました</span>
+      )}
+      {feedback === 'error' && (
+        <span className="text-red-600 whitespace-nowrap">コピーに失敗しました</span>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/features/room/components/room-view.tsx
+++ b/packages/frontend/src/features/room/components/room-view.tsx
@@ -7,6 +7,7 @@ import { CardSelector } from './card-selector';
 import { ParticipantsList } from './participants-list';
 import { VotingResult } from './voting-result';
 import { HostControls } from './host-controls';
+import { InviteLink } from './invite-link';
 
 interface RoomViewProps {
   roomId: string;
@@ -144,6 +145,8 @@ export function RoomView({ roomId, wsUrl, userName, mode }: RoomViewProps) {
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
       <h1 className="text-2xl font-bold">ルーム: {state.roomId}</h1>
+
+      {state.roomId && <InviteLink roomId={state.roomId} />}
 
       {wsError !== null && (
         <div role="alert" className="p-4 bg-red-50 border border-red-300 rounded-lg text-red-700">


### PR DESCRIPTION
## Summary

## 概要

ルーム作成時に参加用の招待URLを生成し、他のメンバーはそのURLを開いて名前を入力するだけでルームに参加できるようにする。

## 現状

- ルームに参加するにはルームIDを手動で入力する必要がある
- ルームIDの共有が手間

## やりたいこと

- ルーム作成後、招待URL（例: `https://<domain>/join/<roomId>`）を表示する
- コピーボタンで簡単にURLをコピーできるようにする
- 招待URLを開いたメンバーは名前を入力するだけで参加可能（ルームIDの入力不要）

## 実装イメージ

### フロントエンド
- `/join/:roomId` ルートを追加
- 招待URL画面: 名前入力フォームのみ表示、送信でルームに参加
- ルーム画面: 招待URLの表示 + コピーボタンを追加

### バックエンド
- 変更不要（既存の `joinRoom` アクションがそのまま使える）


## Execution Report

Piece `default` completed successfully.

Closes #1