### PR TITLE
[#2] github-issue-2-1-github-issue

### DIFF
--- a/packages/frontend/src/app/__tests__/app.test.tsx
+++ b/packages/frontend/src/app/__tests__/app.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+describe('App routing', () => {
+  it('should render JoinRoute at /join/:roomId path', async () => {
+    // Given
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/join/:roomId',
+          lazy: async () => {
+            const { default: JoinRoute } = await import('../../app/routes/join');
+            return { Component: JoinRoute };
+          },
+        },
+      ],
+      { initialEntries: ['/join/room-abc'] },
+    );
+
+    // When
+    render(<RouterProvider router={router} />);
+
+    // Then — JoinView renders the room name and join form
+    expect(await screen.findByText(/room-abc/)).toBeInTheDocument();
+    expect(await screen.findByLabelText(/ユーザー名/)).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /参加/ })).toBeInTheDocument();
+  });
+
+  it('should not match /join without a roomId parameter', async () => {
+    // Given
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/join/:roomId',
+          lazy: async () => {
+            const { default: JoinRoute } = await import('../../app/routes/join');
+            return { Component: JoinRoute };
+          },
+        },
+        {
+          path: '*',
+          element: <div>not-found</div>,
+        },
+      ],
+      { initialEntries: ['/join'] },
+    );
+
+    // When
+    render(<RouterProvider router={router} />);
+
+    // Then
+    expect(await screen.findByText('not-found')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/app/routes/__tests__/join.test.tsx
+++ b/packages/frontend/src/app/routes/__tests__/join.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import JoinRoute from '../join';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function renderJoinRoute(roomId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/join/${roomId}`]}>
+      <Routes>
+        <Route path="/join/:roomId" element={<JoinRoute />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('JoinRoute', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('should pass roomId from URL params to JoinView', () => {
+    // Given
+    const roomId = 'test-room-123';
+
+    // When
+    renderJoinRoute(roomId);
+
+    // Then
+    expect(screen.getByText(/test-room-123/)).toBeInTheDocument();
+  });
+
+  it('should render JoinView with user name input and join button', () => {
+    // Given / When
+    renderJoinRoute('room-abc');
+
+    // Then
+    expect(screen.getByLabelText(/ユーザー名/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /参加/ })).toBeInTheDocument();
+  });
+
+  it('should navigate to /room/:roomId with userName and mode when form is submitted', async () => {
+    // Given
+    const user = userEvent.setup();
+    renderJoinRoute('room-abc');
+
+    // When
+    await user.type(screen.getByLabelText(/ユーザー名/), 'Alice');
+    await user.click(screen.getByRole('button', { name: /参加/ }));
+
+    // Then
+    expect(mockNavigate).toHaveBeenCalledWith('/room/room-abc', {
+      state: { userName: 'Alice', mode: 'join' },
+    });
+  });
+
+  it('should not navigate when userName is empty', async () => {
+    // Given
+    const user = userEvent.setup();
+    renderJoinRoute('room-abc');
+
+    // When
+    await user.click(screen.getByRole('button', { name: /参加/ }));
+
+    // Then
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should not render roomId input field (only name input)', () => {
+    // Given / When
+    renderJoinRoute('room-abc');
+
+    // Then
+    expect(screen.queryByLabelText(/ルームID/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

## Summary

## 概要

ルーム作成時に参加用の招待URLを生成し、他のメンバーはそのURLを開いて名前を入力するだけでルームに参加できるようにする。

## 現状

- ルームに参加するにはルームIDを手動で入力する必要がある
- ルームIDの共有が手間

## やりたいこと

- ルーム作成後、招待URL（例: `https://<domain>/join/<roomId>`）を表示する
- コピーボタンで簡単にURLをコピーできるようにする
- 招待URLを開いたメンバーは名前を入力するだけで参加可能（ルームIDの入力不要）

## 実装イメージ

### フロントエンド
- `/join/:roomId` ルートを追加
- 招待URL画面: 名前入力フォームのみ表示、送信でルームに参加
- ルーム画面: 招待URLの表示 + コピーボタンを追加

### バックエンド
- 変更不要（既存の `joinRoom` アクションがそのまま使える）


## Execution Report

Piece `default` completed successfully.

Closes #1

## Execution Report

Piece `default` completed successfully.

Closes #2