### PR TITLE
[#3] github-issue-3-heddaa-futtaano

### DIFF
--- a/packages/frontend/src/app/routes/home.tsx
+++ b/packages/frontend/src/app/routes/home.tsx
@@ -1,5 +1,10 @@
+import { AppLayout } from '../../components/layout/app-layout';
 import { HomeView } from '../../features/home/components/home-view';
 
 export default function HomeRoute() {
-  return <HomeView />;
+  return (
+    <AppLayout>
+      <HomeView />
+    </AppLayout>
+  );
 }

--- a/packages/frontend/src/app/routes/join.tsx
+++ b/packages/frontend/src/app/routes/join.tsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { useCallback } from 'react';
+import { AppLayout } from '../../components/layout/app-layout';
 import { JoinView } from '../../features/join/components/join-view';
 
 export default function JoinRoute() {
@@ -17,5 +18,9 @@ export default function JoinRoute() {
     [navigate, roomId],
   );
 
-  return <JoinView roomId={roomId} onSubmit={handleSubmit} />;
+  return (
+    <AppLayout>
+      <JoinView roomId={roomId} onSubmit={handleSubmit} />
+    </AppLayout>
+  );
 }

--- a/packages/frontend/src/app/routes/room.tsx
+++ b/packages/frontend/src/app/routes/room.tsx
@@ -1,5 +1,8 @@
 import { useParams, useLocation } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { AppLayout } from '../../components/layout/app-layout';
+import { RoomIdCopy } from '../../components/layout/room-id-copy';
+import { ConnectionStatusBadge, type ConnectionStatus } from '../../components/layout/connection-status';
 import { RoomView } from '../../features/room/components/room-view';
 import { getConfig } from '../../shared/lib/config';
 
@@ -12,6 +15,7 @@ export default function RoomRoute() {
 
   const [wsUrl, setWsUrl] = useState<string | null>(null);
   const [configError, setConfigError] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
 
   useEffect(() => {
     getConfig()
@@ -31,13 +35,39 @@ export default function RoomRoute() {
     throw new Error('mode is required');
   }
 
+  const headerCenter = <RoomIdCopy roomId={roomId} />;
+  const headerRight = (
+    <>
+      <span className="text-sm">{userName}</span>
+      <ConnectionStatusBadge status={connectionStatus} />
+    </>
+  );
+
   if (configError) {
-    return <p className="text-red-600 p-8">WebSocket URL が設定されていません</p>;
+    return (
+      <AppLayout headerCenter={headerCenter} headerRight={headerRight}>
+        <p className="text-red-600 p-8">WebSocket URL が設定されていません</p>
+      </AppLayout>
+    );
   }
 
   if (!wsUrl) {
-    return <p className="p-8">読み込み中...</p>;
+    return (
+      <AppLayout headerCenter={headerCenter} headerRight={headerRight}>
+        <p className="p-8">読み込み中...</p>
+      </AppLayout>
+    );
   }
 
-  return <RoomView roomId={roomId} wsUrl={wsUrl} userName={userName} mode={mode} />;
+  return (
+    <AppLayout headerCenter={headerCenter} headerRight={headerRight}>
+      <RoomView
+        roomId={roomId}
+        wsUrl={wsUrl}
+        userName={userName}
+        mode={mode}
+        onConnectionStatusChange={setConnectionStatus}
+      />
+    </AppLayout>
+  );
 }

--- a/packages/frontend/src/components/layout/__tests__/app-footer.test.tsx
+++ b/packages/frontend/src/components/layout/__tests__/app-footer.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AppFooter } from '../app-footer';
+import { APP_NAME } from '../constants';
+
+describe('AppFooter', () => {
+  it('should display the app name', () => {
+    // Given / When
+    render(<AppFooter />);
+
+    // Then
+    expect(screen.getByText(APP_NAME)).toBeInTheDocument();
+  });
+
+  it('should render as a footer element', () => {
+    // Given / When
+    render(<AppFooter />);
+
+    // Then
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/layout/__tests__/app-header.test.tsx
+++ b/packages/frontend/src/components/layout/__tests__/app-header.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AppHeader } from '../app-header';
+import { APP_NAME } from '../constants';
+
+describe('AppHeader', () => {
+  it('should display the app name', () => {
+    // Given / When
+    render(<AppHeader />);
+
+    // Then
+    expect(screen.getByText(APP_NAME)).toBeInTheDocument();
+  });
+
+  it('should render as a banner element', () => {
+    // Given / When
+    render(<AppHeader />);
+
+    // Then
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
+  it('should render center slot when provided', () => {
+    // Given / When
+    render(<AppHeader center={<span>Center Content</span>} />);
+
+    // Then
+    expect(screen.getByText('Center Content')).toBeInTheDocument();
+  });
+
+  it('should render right slot when provided', () => {
+    // Given / When
+    render(<AppHeader right={<span>Right Content</span>} />);
+
+    // Then
+    expect(screen.getByText('Right Content')).toBeInTheDocument();
+  });
+
+  it('should not render center area when center is not provided', () => {
+    // Given / When
+    render(<AppHeader />);
+
+    // Then
+    const banner = screen.getByRole('banner');
+    const flexChildren = banner.querySelector('.mx-auto')!.children;
+    expect(flexChildren).toHaveLength(1);
+  });
+});

--- a/packages/frontend/src/components/layout/__tests__/app-layout.test.tsx
+++ b/packages/frontend/src/components/layout/__tests__/app-layout.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AppLayout } from '../app-layout';
+import { APP_NAME } from '../constants';
+
+describe('AppLayout', () => {
+  it('should render header, main content, and footer', () => {
+    // Given / When
+    render(
+      <AppLayout>
+        <p>Page Content</p>
+      </AppLayout>,
+    );
+
+    // Then
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+    expect(screen.getByText('Page Content')).toBeInTheDocument();
+  });
+
+  it('should render app name in both header and footer', () => {
+    // Given / When
+    render(
+      <AppLayout>
+        <p>Content</p>
+      </AppLayout>,
+    );
+
+    // Then
+    const appNameElements = screen.getAllByText(APP_NAME);
+    expect(appNameElements).toHaveLength(2);
+  });
+
+  it('should pass headerCenter and headerRight to the header', () => {
+    // Given / When
+    render(
+      <AppLayout
+        headerCenter={<span>Center</span>}
+        headerRight={<span>Right</span>}
+      >
+        <p>Content</p>
+      </AppLayout>,
+    );
+
+    // Then
+    expect(screen.getByText('Center')).toBeInTheDocument();
+    expect(screen.getByText('Right')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/layout/__tests__/connection-status.test.tsx
+++ b/packages/frontend/src/components/layout/__tests__/connection-status.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConnectionStatusBadge, type ConnectionStatus } from '../connection-status';
+
+describe('ConnectionStatusBadge', () => {
+  it('should display "接続中" when connected', () => {
+    // Given / When
+    render(<ConnectionStatusBadge status="connected" />);
+
+    // Then
+    expect(screen.getByText('接続中')).toBeInTheDocument();
+  });
+
+  it('should display "接続待ち" when connecting', () => {
+    // Given / When
+    render(<ConnectionStatusBadge status="connecting" />);
+
+    // Then
+    expect(screen.getByText('接続待ち')).toBeInTheDocument();
+  });
+
+  it('should display "切断" when disconnected', () => {
+    // Given / When
+    render(<ConnectionStatusBadge status="disconnected" />);
+
+    // Then
+    expect(screen.getByText('切断')).toBeInTheDocument();
+  });
+
+  it('should render all status variants without errors', () => {
+    // Given
+    const statuses: ConnectionStatus[] = ['connected', 'connecting', 'disconnected'];
+
+    // When / Then
+    for (const status of statuses) {
+      const { unmount } = render(<ConnectionStatusBadge status={status} />);
+      unmount();
+    }
+  });
+});

--- a/packages/frontend/src/components/layout/__tests__/room-id-copy.test.tsx
+++ b/packages/frontend/src/components/layout/__tests__/room-id-copy.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RoomIdCopy } from '../room-id-copy';
+
+describe('RoomIdCopy', () => {
+  it('should display the room ID', () => {
+    // Given / When
+    render(<RoomIdCopy roomId="test-room-123" />);
+
+    // Then
+    expect(screen.getByText(/test-room-123/)).toBeInTheDocument();
+  });
+
+  it('should render a copy button', () => {
+    // Given / When
+    render(<RoomIdCopy roomId="test-room-123" />);
+
+    // Then
+    expect(screen.getByRole('button', { name: /コピー/ })).toBeInTheDocument();
+  });
+
+  it('should copy the room ID to clipboard when copy button is clicked', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<RoomIdCopy roomId="test-room-123" />);
+    const writeTextSpy = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue(undefined);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /コピー/ }));
+
+    // Then
+    expect(writeTextSpy).toHaveBeenCalledWith('test-room-123');
+  });
+
+  it('should show feedback after successful copy', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<RoomIdCopy roomId="test-room-123" />);
+    vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+
+    // When
+    await user.click(screen.getByRole('button', { name: /コピー/ }));
+
+    // Then
+    expect(screen.getByText(/コピーしました/)).toBeInTheDocument();
+  });
+
+  it('should show error feedback when clipboard write fails', async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<RoomIdCopy roomId="test-room-123" />);
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(
+      new Error('denied'),
+    );
+
+    // When
+    await user.click(screen.getByRole('button', { name: /コピー/ }));
+
+    // Then
+    expect(screen.getByText(/コピーに失敗しました/)).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/layout/app-footer.tsx
+++ b/packages/frontend/src/components/layout/app-footer.tsx
@@ -1,0 +1,9 @@
+import { APP_NAME } from './constants';
+
+export function AppFooter() {
+  return (
+    <footer className="border-t border-border py-4 text-center text-sm text-muted-foreground">
+      {APP_NAME}
+    </footer>
+  );
+}

--- a/packages/frontend/src/components/layout/app-header.tsx
+++ b/packages/frontend/src/components/layout/app-header.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+import { APP_NAME } from './constants';
+
+interface AppHeaderProps {
+  center?: ReactNode;
+  right?: ReactNode;
+}
+
+export function AppHeader({ center, right }: AppHeaderProps) {
+  return (
+    <header className="border-b border-border px-6 py-3">
+      <div className="mx-auto flex max-w-4xl items-center">
+        <div className="flex-1">
+          <span className="text-lg font-bold">{APP_NAME}</span>
+        </div>
+        {center && <div className="flex-1 flex justify-center">{center}</div>}
+        {right && <div className="flex-1 flex justify-end items-center gap-2">{right}</div>}
+      </div>
+    </header>
+  );
+}

--- a/packages/frontend/src/components/layout/app-layout.tsx
+++ b/packages/frontend/src/components/layout/app-layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { AppHeader } from './app-header';
+import { AppFooter } from './app-footer';
+
+interface AppLayoutProps {
+  headerCenter?: ReactNode;
+  headerRight?: ReactNode;
+  children: ReactNode;
+}
+
+export function AppLayout({ headerCenter, headerRight, children }: AppLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <AppHeader center={headerCenter} right={headerRight} />
+      <main className="flex-1">{children}</main>
+      <AppFooter />
+    </div>
+  );
+}

--- a/packages/frontend/src/components/layout/connection-status.tsx
+++ b/packages/frontend/src/components/layout/connection-status.tsx
@@ -1,0 +1,18 @@
+import { Badge } from '../ui/badge';
+
+export type ConnectionStatus = 'connected' | 'disconnected' | 'connecting';
+
+const STATUS_CONFIG: Record<ConnectionStatus, { label: string; variant: 'default' | 'secondary' | 'destructive' }> = {
+  connected: { label: '接続中', variant: 'default' },
+  connecting: { label: '接続待ち', variant: 'secondary' },
+  disconnected: { label: '切断', variant: 'destructive' },
+};
+
+interface ConnectionStatusBadgeProps {
+  status: ConnectionStatus;
+}
+
+export function ConnectionStatusBadge({ status }: ConnectionStatusBadgeProps) {
+  const config = STATUS_CONFIG[status];
+  return <Badge variant={config.variant}>{config.label}</Badge>;
+}

--- a/packages/frontend/src/components/layout/constants.ts
+++ b/packages/frontend/src/components/layout/constants.ts
@@ -1,0 +1,1 @@
+export const APP_NAME = 'Planning Poker';

--- a/packages/frontend/src/components/layout/room-id-copy.tsx
+++ b/packages/frontend/src/components/layout/room-id-copy.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { Button } from '../ui/button';
+
+interface RoomIdCopyProps {
+  roomId: string;
+}
+
+export function RoomIdCopy({ roomId }: RoomIdCopyProps) {
+  const [feedback, setFeedback] = useState<'copied' | 'error' | null>(null);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(roomId);
+      setFeedback('copied');
+    } catch {
+      setFeedback('error');
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm font-medium">Room: {roomId}</span>
+      <Button variant="ghost" size="xs" onClick={handleCopy}>
+        コピー
+      </Button>
+      {feedback === 'copied' && (
+        <span className="text-xs text-green-600">コピーしました</span>
+      )}
+      {feedback === 'error' && (
+        <span className="text-xs text-red-600">コピーに失敗しました</span>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/features/home/components/home-view.tsx
+++ b/packages/frontend/src/features/home/components/home-view.tsx
@@ -16,7 +16,6 @@ export function HomeView() {
 
   return (
     <div className="max-w-md mx-auto p-8 space-y-8">
-      <h1 className="text-3xl font-bold text-center">プランニングポーカー</h1>
       <section>
         <h2 className="text-xl font-semibold mb-4">ルーム作成</h2>
         <CreateRoomForm onSubmit={handleCreateRoom} />

--- a/packages/frontend/src/features/room/components/room-view.tsx
+++ b/packages/frontend/src/features/room/components/room-view.tsx
@@ -14,6 +14,7 @@ interface RoomViewProps {
   wsUrl: string;
   userName: string;
   mode: 'create' | 'join';
+  onConnectionStatusChange: (status: 'connected' | 'disconnected' | 'connecting') => void;
 }
 
 type RoomCreatedAction = Extract<ServerMessage, { type: 'roomCreated' }>;
@@ -84,9 +85,13 @@ function createInitialState(roomId: string): RoomState {
   };
 }
 
-export function RoomView({ roomId, wsUrl, userName, mode }: RoomViewProps) {
+export function RoomView({ roomId, wsUrl, userName, mode, onConnectionStatusChange }: RoomViewProps) {
   const navigate = useNavigate();
   const { status: wsStatus, lastMessage, error: wsError, connect, send } = useWebSocket(wsUrl);
+
+  useEffect(() => {
+    onConnectionStatusChange(wsStatus);
+  }, [wsStatus, onConnectionStatusChange]);
   const [state, dispatch] = useReducer(viewReducer, roomId, createInitialState);
   const [selectedCard, setSelectedCard] = useState<string | null>(null);
   // roomCreated後のnavigate→useEffect再発火で二重送信されるのを防止
@@ -151,8 +156,6 @@ export function RoomView({ roomId, wsUrl, userName, mode }: RoomViewProps) {
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-8">
-      <h1 className="text-2xl font-bold">ルーム: {state.roomId}</h1>
-
       {state.roomId && <InviteLink roomId={state.roomId} />}
 
       {wsError !== null && (

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     globals: false,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

## 概要
全ページ共通のヘッダー・フッターレイアウトを追加して、UIの見た目を整える。

## ヘッダー
- 左: アプリ名「Planning Poker」
- 中央: ルームID（コピーボタン付き）※ルーム内のみ
- 右: 自分の名前 + 接続ステータス ※ルーム内のみ

## フッター
- シンプルに「Planning Poker」表示

## ルーム外（トップページ）
- ヘッダーはアプリ名のみ
- フッターは共通

## 実装方針
- 共通レイアウトコンポーネントとして作成
- shadcn/ui のコンポーネントを活用
- ルーム内ではルーム情報をヘッダーに表示

## Execution Report

Piece `frontend-mini` completed successfully.

Closes #3