### PR TITLE
[#6] github-issue-6-shinpuruna-peej

### DIFF
--- a/packages/frontend/src/app/app.tsx
+++ b/packages/frontend/src/app/app.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import HomeRoute from './routes/home';
 import RoomRoute from './routes/room';
 import JoinRoute from './routes/join';
+import TermsRoute from './routes/terms';
 
 export function App() {
   return (
@@ -10,6 +11,7 @@ export function App() {
         <Route path="/" element={<HomeRoute />} />
         <Route path="/room/:roomId" element={<RoomRoute />} />
         <Route path="/join/:roomId" element={<JoinRoute />} />
+        <Route path="/terms" element={<TermsRoute />} />
       </Routes>
     </BrowserRouter>
   );

--- a/packages/frontend/src/app/routes/terms.tsx
+++ b/packages/frontend/src/app/routes/terms.tsx
@@ -1,0 +1,10 @@
+import { AppLayout } from '../../components/layout/app-layout';
+import { TermsView } from '../../features/terms/components/terms-view';
+
+export default function TermsRoute() {
+  return (
+    <AppLayout>
+      <TermsView />
+    </AppLayout>
+  );
+}

--- a/packages/frontend/src/components/layout/__tests__/app-footer.test.tsx
+++ b/packages/frontend/src/components/layout/__tests__/app-footer.test.tsx
@@ -1,12 +1,21 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { AppFooter } from '../app-footer';
 import { APP_NAME } from '../constants';
+
+function renderWithRouter() {
+  return render(
+    <MemoryRouter>
+      <AppFooter />
+    </MemoryRouter>,
+  );
+}
 
 describe('AppFooter', () => {
   it('should display the app name', () => {
     // Given / When
-    render(<AppFooter />);
+    renderWithRouter();
 
     // Then
     expect(screen.getByText(APP_NAME)).toBeInTheDocument();
@@ -14,9 +23,19 @@ describe('AppFooter', () => {
 
   it('should render as a footer element', () => {
     // Given / When
-    render(<AppFooter />);
+    renderWithRouter();
 
     // Then
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  it('should display a link to the terms page', () => {
+    // Given / When
+    renderWithRouter();
+
+    // Then
+    const termsLink = screen.getByRole('link', { name: '利用規約' });
+    expect(termsLink).toBeInTheDocument();
+    expect(termsLink).toHaveAttribute('href', '/terms');
   });
 });

--- a/packages/frontend/src/components/layout/__tests__/app-layout.test.tsx
+++ b/packages/frontend/src/components/layout/__tests__/app-layout.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { AppLayout } from '../app-layout';
 import { APP_NAME } from '../constants';
 
@@ -7,9 +8,11 @@ describe('AppLayout', () => {
   it('should render header, main content, and footer', () => {
     // Given / When
     render(
-      <AppLayout>
-        <p>Page Content</p>
-      </AppLayout>,
+      <MemoryRouter>
+        <AppLayout>
+          <p>Page Content</p>
+        </AppLayout>
+      </MemoryRouter>,
     );
 
     // Then
@@ -22,9 +25,11 @@ describe('AppLayout', () => {
   it('should render app name in both header and footer', () => {
     // Given / When
     render(
-      <AppLayout>
-        <p>Content</p>
-      </AppLayout>,
+      <MemoryRouter>
+        <AppLayout>
+          <p>Content</p>
+        </AppLayout>
+      </MemoryRouter>,
     );
 
     // Then
@@ -35,12 +40,14 @@ describe('AppLayout', () => {
   it('should pass headerCenter and headerRight to the header', () => {
     // Given / When
     render(
-      <AppLayout
-        headerCenter={<span>Center</span>}
-        headerRight={<span>Right</span>}
-      >
-        <p>Content</p>
-      </AppLayout>,
+      <MemoryRouter>
+        <AppLayout
+          headerCenter={<span>Center</span>}
+          headerRight={<span>Right</span>}
+        >
+          <p>Content</p>
+        </AppLayout>
+      </MemoryRouter>,
     );
 
     // Then

--- a/packages/frontend/src/components/layout/app-footer.tsx
+++ b/packages/frontend/src/components/layout/app-footer.tsx
@@ -1,9 +1,15 @@
+import { Link } from 'react-router-dom';
 import { APP_NAME } from './constants';
 
 export function AppFooter() {
   return (
     <footer className="border-t border-border py-4 text-center text-sm text-muted-foreground">
-      {APP_NAME}
+      <div className="flex items-center justify-center gap-4">
+        <span>{APP_NAME}</span>
+        <Link to="/terms" className="underline hover:text-foreground">
+          利用規約
+        </Link>
+      </div>
     </footer>
   );
 }

--- a/packages/frontend/src/features/terms/components/__tests__/terms-view.test.tsx
+++ b/packages/frontend/src/features/terms/components/__tests__/terms-view.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TermsView } from '../terms-view';
+
+describe('TermsView', () => {
+  it('should display the page title', () => {
+    // Given / When
+    render(<TermsView />);
+
+    // Then
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      '利用規約',
+    );
+  });
+
+  it('should display the service overview section', () => {
+    // Given / When
+    render(<TermsView />);
+
+    // Then
+    expect(screen.getByText('サービスの概要')).toBeInTheDocument();
+    expect(
+      screen.getByText(/プランニングポーカーツール/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/アカウント登録不要/),
+    ).toBeInTheDocument();
+  });
+
+  it('should display the data handling section', () => {
+    // Given / When
+    render(<TermsView />);
+
+    // Then
+    expect(screen.getByText('データの取り扱い')).toBeInTheDocument();
+    expect(
+      screen.getByText(/一時的に保存/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/個人情報の永続的な保存は行いません/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cookieやトラッキングは使用しません/),
+    ).toBeInTheDocument();
+  });
+
+  it('should display the disclaimer section', () => {
+    // Given / When
+    render(<TermsView />);
+
+    // Then
+    expect(screen.getByText('免責事項')).toBeInTheDocument();
+    expect(
+      screen.getByText(/現状のまま/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/中断・終了・変更を予告なく行う/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/損害について責任を負いません/),
+    ).toBeInTheDocument();
+  });
+
+  it('should display the prohibited actions section', () => {
+    // Given / When
+    render(<TermsView />);
+
+    // Then
+    expect(screen.getByText('禁止事項')).toBeInTheDocument();
+    expect(
+      screen.getByText(/不正アクセスや過度な負荷/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/他のユーザーの利用を妨げる/),
+    ).toBeInTheDocument();
+  });
+
+  it('should display the terms change section', () => {
+    // Given / When
+    render(<TermsView />);
+
+    // Then
+    expect(screen.getByText('規約の変更')).toBeInTheDocument();
+    expect(
+      screen.getByText(/予告なく変更される場合があります/),
+    ).toBeInTheDocument();
+  });
+
+  it('should render all five sections', () => {
+    // Given / When
+    render(<TermsView />);
+
+    // Then
+    const sectionHeadings = screen.getAllByRole('heading', { level: 2 });
+    expect(sectionHeadings).toHaveLength(5);
+  });
+});

--- a/packages/frontend/src/features/terms/components/terms-view.tsx
+++ b/packages/frontend/src/features/terms/components/terms-view.tsx
@@ -1,0 +1,66 @@
+const SECTIONS = [
+  {
+    title: 'サービスの概要',
+    items: [
+      '本サービスはチーム開発向けのプランニングポーカーツールです。',
+      'アカウント登録不要で利用できます。',
+    ],
+  },
+  {
+    title: 'データの取り扱い',
+    items: [
+      'ユーザー名・投票データは一時的に保存され、一定時間後に自動削除されます。',
+      '個人情報の永続的な保存は行いません。',
+      'Cookieやトラッキングは使用しません。',
+    ],
+  },
+  {
+    title: '免責事項',
+    items: [
+      'サービスは「現状のまま」提供されます。',
+      'サービスの中断・終了・変更を予告なく行う場合があります。',
+      'サービス利用により生じた損害について責任を負いません。',
+    ],
+  },
+  {
+    title: '禁止事項',
+    items: [
+      'サービスへの不正アクセスや過度な負荷をかける行為。',
+      '他のユーザーの利用を妨げる行為。',
+    ],
+  },
+  {
+    title: '規約の変更',
+    items: [
+      '利用規約は予告なく変更される場合があります。',
+    ],
+  },
+] as const;
+
+function TermsSection({ title, items }: { title: string; items: readonly string[] }) {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-2">{title}</h2>
+      <ul className="list-disc pl-6 space-y-1 text-muted-foreground">
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function TermsView() {
+  return (
+    <div className="max-w-2xl mx-auto p-8 space-y-6">
+      <h1 className="text-2xl font-bold">利用規約</h1>
+      {SECTIONS.map((section) => (
+        <TermsSection
+          key={section.title}
+          title={section.title}
+          items={section.items}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

## 概要
シンプルな利用規約ページを作成し、フッターからリンクする。

## 利用規約に含める内容

### 1. サービスの概要
- 本サービスはチーム開発向けのプランニングポーカーツールです
- アカウント登録不要で利用できます

### 2. データの取り扱い
- ユーザー名・投票データは一時的に保存され、一定時間後に自動削除されます
- 個人情報の永続的な保存は行いません
- Cookie やトラッキングは使用しません

### 3. 免責事項
- サービスは「現状のまま」提供されます
- サービスの中断・終了・変更を予告なく行う場合があります
- サービス利用により生じた損害について責任を負いません

### 4. 禁止事項
- サービスへの不正アクセスや過度な負荷をかける行為
- 他のユーザーの利用を妨げる行為

### 5. 規約の変更
- 利用規約は予告なく変更される場合があります

## 実装方針
- `/terms` ルートに利用規約ページを追加
- フッターに「利用規約」リンクを追加
- 静的なページとしてシンプルに実装

## Execution Report

Piece `default` completed successfully.

Closes #6