### PR TITLE
[#11] github-issue-11-hostconnection

### DIFF
--- a/packages/backend/src/actions/__tests__/createRoom.test.ts
+++ b/packages/backend/src/actions/__tests__/createRoom.test.ts
@@ -39,7 +39,7 @@ describe('createRoom', () => {
     expect(savedConnection.roomId.length).toBeGreaterThan(0);
   });
 
-  it('should create room with host as first participant', async () => {
+  it('should create room with creator as first participant', async () => {
     // When
     await createRoom(connectionId, userName);
 
@@ -47,9 +47,9 @@ describe('createRoom', () => {
     expect(mockCreateRoomInDb).toHaveBeenCalledOnce();
     const createdRoom = mockCreateRoomInDb.mock.calls[0][0];
     expect(createdRoom).toMatchObject({
-      hostConnectionId: connectionId,
       status: 'voting',
     });
+    expect(createdRoom).not.toHaveProperty('hostConnectionId');
     expect(createdRoom.roomId).toEqual(expect.any(String));
     expect(createdRoom.participants).toHaveProperty(connectionId);
     expect(createdRoom.participants[connectionId]).toMatchObject({
@@ -74,10 +74,13 @@ describe('createRoom', () => {
         you: expect.objectContaining({
           connectionId,
           userName,
-          isHost: true,
         }),
       }),
     );
+    const sentMessage = mockSendToConnection.mock.calls[0][1] as {
+      you: Record<string, unknown>;
+    };
+    expect(sentMessage.you).not.toHaveProperty('isHost');
   });
 
   it('should generate a unique roomId', async () => {

--- a/packages/backend/src/actions/__tests__/helpers.test.ts
+++ b/packages/backend/src/actions/__tests__/helpers.test.ts
@@ -24,7 +24,6 @@ describe('requireConnectionAndRoom', () => {
     };
     const room = {
       roomId: 'room-1',
-      hostConnectionId: 'conn-host',
       status: 'voting' as const,
       participants: {},
       ttl: 9999,

--- a/packages/backend/src/actions/__tests__/joinRoom.test.ts
+++ b/packages/backend/src/actions/__tests__/joinRoom.test.ts
@@ -23,12 +23,11 @@ function createRoomFixture(
 ) {
   return {
     roomId: 'room-xyz',
-    hostConnectionId: 'conn-host',
     status: 'voting' as const,
     participants: {
-      'conn-host': {
-        connectionId: 'conn-host',
-        userName: 'Host',
+      'conn-creator': {
+        connectionId: 'conn-creator',
+        userName: 'Creator',
         vote: null,
         hasVoted: false,
       },
@@ -126,10 +125,13 @@ describe('joinRoom', () => {
         you: expect.objectContaining({
           connectionId,
           userName,
-          isHost: false,
         }),
       }),
     );
+    const sentMessage = mockSendToConnection.mock.calls[0][1] as {
+      you: Record<string, unknown>;
+    };
+    expect(sentMessage.you).not.toHaveProperty('isHost');
   });
 
   it('should throw when room does not exist', async () => {

--- a/packages/backend/src/actions/__tests__/reset.test.ts
+++ b/packages/backend/src/actions/__tests__/reset.test.ts
@@ -18,9 +18,9 @@ function createConnectionFixture(
   overrides: Record<string, unknown> = {},
 ) {
   return {
-    connectionId: 'conn-host',
+    connectionId: 'conn-creator',
     roomId: 'room-xyz',
-    userName: 'Host',
+    userName: 'Creator',
     ttl: Math.floor(Date.now() / 1000) + 9000,
     ...overrides,
   };
@@ -31,12 +31,11 @@ function createRoomFixture(
 ) {
   return {
     roomId: 'room-xyz',
-    hostConnectionId: 'conn-host',
     status: 'revealed' as const,
     participants: {
-      'conn-host': {
-        connectionId: 'conn-host',
-        userName: 'Host',
+      'conn-creator': {
+        connectionId: 'conn-creator',
+        userName: 'Creator',
         vote: '5',
         hasVoted: true,
       },
@@ -53,7 +52,7 @@ function createRoomFixture(
 }
 
 describe('reset', () => {
-  const hostConnectionId = 'conn-host';
+  const connectionId = 'conn-creator';
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,7 +68,7 @@ describe('reset', () => {
     mockGetRoom.mockResolvedValue(createRoomFixture());
 
     // When
-    await reset(hostConnectionId);
+    await reset(connectionId);
 
     // Then
     expect(mockResetVotes).toHaveBeenCalledWith('room-xyz');
@@ -83,7 +82,7 @@ describe('reset', () => {
     mockGetRoom.mockResolvedValue(createRoomFixture());
 
     // When
-    await reset(hostConnectionId);
+    await reset(connectionId);
 
     // Then
     expect(mockBroadcastToRoom).toHaveBeenCalledWith(
@@ -97,6 +96,6 @@ describe('reset', () => {
     mockGetConnection.mockResolvedValue(null);
 
     // When & Then
-    await expect(reset(hostConnectionId)).rejects.toThrow();
+    await expect(reset(connectionId)).rejects.toThrow();
   });
 });

--- a/packages/backend/src/actions/__tests__/reveal.test.ts
+++ b/packages/backend/src/actions/__tests__/reveal.test.ts
@@ -18,9 +18,9 @@ function createConnectionFixture(
   overrides: Record<string, unknown> = {},
 ) {
   return {
-    connectionId: 'conn-host',
+    connectionId: 'conn-creator',
     roomId: 'room-xyz',
-    userName: 'Host',
+    userName: 'Creator',
     ttl: Math.floor(Date.now() / 1000) + 9000,
     ...overrides,
   };
@@ -31,12 +31,11 @@ function createRoomFixture(
 ) {
   return {
     roomId: 'room-xyz',
-    hostConnectionId: 'conn-host',
     status: 'voting' as const,
     participants: {
-      'conn-host': {
-        connectionId: 'conn-host',
-        userName: 'Host',
+      'conn-creator': {
+        connectionId: 'conn-creator',
+        userName: 'Creator',
         vote: '5',
         hasVoted: true,
       },
@@ -53,7 +52,7 @@ function createRoomFixture(
 }
 
 describe('reveal', () => {
-  const hostConnectionId = 'conn-host';
+  const connectionId = 'conn-creator';
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,7 +68,7 @@ describe('reveal', () => {
     mockGetRoom.mockResolvedValue(createRoomFixture());
 
     // When
-    await reveal(hostConnectionId);
+    await reveal(connectionId);
 
     // Then
     expect(mockUpdateStatus).toHaveBeenCalledWith(
@@ -86,7 +85,7 @@ describe('reveal', () => {
     mockGetRoom.mockResolvedValue(createRoomFixture());
 
     // When
-    await reveal(hostConnectionId);
+    await reveal(connectionId);
 
     // Then
     expect(mockBroadcastToRoom).toHaveBeenCalledWith(
@@ -94,7 +93,7 @@ describe('reveal', () => {
       expect.objectContaining({
         type: 'revealed',
         participants: expect.arrayContaining([
-          expect.objectContaining({ userName: 'Host', vote: '5' }),
+          expect.objectContaining({ userName: 'Creator', vote: '5' }),
           expect.objectContaining({
             userName: 'Member',
             vote: '8',
@@ -112,9 +111,9 @@ describe('reveal', () => {
     );
     const room = createRoomFixture({
       participants: {
-        'conn-host': {
-          connectionId: 'conn-host',
-          userName: 'Host',
+        'conn-creator': {
+          connectionId: 'conn-creator',
+          userName: 'Creator',
           vote: '3',
           hasVoted: true,
         },
@@ -135,7 +134,7 @@ describe('reveal', () => {
     mockGetRoom.mockResolvedValue(room);
 
     // When
-    await reveal(hostConnectionId);
+    await reveal(connectionId);
 
     // Then
     const broadcastMessage =
@@ -152,9 +151,9 @@ describe('reveal', () => {
     );
     const room = createRoomFixture({
       participants: {
-        'conn-host': {
-          connectionId: 'conn-host',
-          userName: 'Host',
+        'conn-creator': {
+          connectionId: 'conn-creator',
+          userName: 'Creator',
           vote: '?',
           hasVoted: true,
         },
@@ -163,7 +162,7 @@ describe('reveal', () => {
     mockGetRoom.mockResolvedValue(room);
 
     // When
-    await reveal(hostConnectionId);
+    await reveal(connectionId);
 
     // Then
     const broadcastMessage =
@@ -183,6 +182,6 @@ describe('reveal', () => {
     );
 
     // When & Then
-    await expect(reveal(hostConnectionId)).rejects.toThrow();
+    await expect(reveal(connectionId)).rejects.toThrow();
   });
 });

--- a/packages/backend/src/actions/__tests__/vote.test.ts
+++ b/packages/backend/src/actions/__tests__/vote.test.ts
@@ -33,12 +33,11 @@ function createRoomFixture(
 ) {
   return {
     roomId: 'room-xyz',
-    hostConnectionId: 'conn-host',
     status: 'voting' as const,
     participants: {
-      'conn-host': {
-        connectionId: 'conn-host',
-        userName: 'Host',
+      'conn-creator': {
+        connectionId: 'conn-creator',
+        userName: 'Creator',
         vote: null,
         hasVoted: false,
       },

--- a/packages/backend/src/actions/createRoom.ts
+++ b/packages/backend/src/actions/createRoom.ts
@@ -24,7 +24,6 @@ export async function createRoom(
 
   await createRoomInDb({
     roomId,
-    hostConnectionId: connectionId,
     status: 'voting',
     participants: {
       [connectionId]: {
@@ -43,7 +42,6 @@ export async function createRoom(
     you: {
       connectionId,
       userName,
-      isHost: true,
     },
   });
 }

--- a/packages/backend/src/actions/joinRoom.ts
+++ b/packages/backend/src/actions/joinRoom.ts
@@ -61,7 +61,6 @@ export async function joinRoom(
     you: {
       connectionId,
       userName,
-      isHost: false,
     },
   });
 }

--- a/packages/backend/src/handlers/__tests__/disconnect.test.ts
+++ b/packages/backend/src/handlers/__tests__/disconnect.test.ts
@@ -50,12 +50,11 @@ function createConnectionFixture(
 function createRoomFixture() {
   return {
     roomId: 'room-xyz',
-    hostConnectionId: 'conn-host',
     status: 'voting' as const,
     participants: {
-      'conn-host': {
-        connectionId: 'conn-host',
-        userName: 'Host',
+      'conn-creator': {
+        connectionId: 'conn-creator',
+        userName: 'Creator',
         vote: null,
         hasVoted: false,
       },

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -16,7 +16,6 @@ export type RoomStatus = 'voting' | 'revealed';
 
 export interface Room {
   roomId: string;
-  hostConnectionId: string;
   status: RoomStatus;
   participants: Record<string, Participant>;
   ttl: number;

--- a/packages/backend/src/websocket/__tests__/broadcast.test.ts
+++ b/packages/backend/src/websocket/__tests__/broadcast.test.ts
@@ -26,7 +26,6 @@ function createRoomFixture(
 ) {
   return {
     roomId: 'room-1',
-    hostConnectionId: 'conn-host',
     status: 'voting' as const,
     participants,
     ttl: Math.floor(Date.now() / 1000) + 86400,

--- a/packages/frontend/src/features/room/__tests__/room-reducer.test.ts
+++ b/packages/frontend/src/features/room/__tests__/room-reducer.test.ts
@@ -6,11 +6,10 @@ function createInitialState(overrides: Partial<RoomState> = {}): RoomState {
     roomId: 'room-abc',
     status: 'voting',
     participants: new Map([
-      ['conn-host', { connectionId: 'conn-host', userName: 'Host', hasVoted: false, vote: null }],
+      ['conn-creator', { connectionId: 'conn-creator', userName: 'Creator', hasVoted: false, vote: null }],
     ]),
-    myConnectionId: 'conn-host',
-    myUserName: 'Host',
-    isHost: true,
+    myConnectionId: 'conn-creator',
+    myUserName: 'Creator',
     average: null,
     ...overrides,
   };
@@ -60,7 +59,7 @@ describe('roomReducer', () => {
       // Given
       const state = createInitialState({
         participants: new Map([
-          ['conn-host', { connectionId: 'conn-host', userName: 'Host', hasVoted: false, vote: null }],
+          ['conn-creator', { connectionId: 'conn-creator', userName: 'Creator', hasVoted: false, vote: null }],
           ['conn-alice', { connectionId: 'conn-alice', userName: 'Alice', hasVoted: false, vote: null }],
         ]),
       });
@@ -98,14 +97,14 @@ describe('roomReducer', () => {
       // Given
       const state = createInitialState({
         participants: new Map([
-          ['conn-host', { connectionId: 'conn-host', userName: 'Host', hasVoted: false, vote: null }],
+          ['conn-creator', { connectionId: 'conn-creator', userName: 'Creator', hasVoted: false, vote: null }],
           ['conn-alice', { connectionId: 'conn-alice', userName: 'Alice', hasVoted: false, vote: null }],
         ]),
       });
       const action: RoomAction = {
         type: 'voteUpdate',
         participants: [
-          { connectionId: 'conn-host', userName: 'Host', hasVoted: true },
+          { connectionId: 'conn-creator', userName: 'Creator', hasVoted: true },
           { connectionId: 'conn-alice', userName: 'Alice', hasVoted: false },
         ],
       };
@@ -114,7 +113,7 @@ describe('roomReducer', () => {
       const next = roomReducer(state, action);
 
       // Then
-      expect(next.participants.get('conn-host')?.hasVoted).toBe(true);
+      expect(next.participants.get('conn-creator')?.hasVoted).toBe(true);
       expect(next.participants.get('conn-alice')?.hasVoted).toBe(false);
     });
 
@@ -124,7 +123,7 @@ describe('roomReducer', () => {
       const action: RoomAction = {
         type: 'voteUpdate',
         participants: [
-          { connectionId: 'conn-host', userName: 'Host', hasVoted: true },
+          { connectionId: 'conn-creator', userName: 'Creator', hasVoted: true },
         ],
       };
 
@@ -143,7 +142,7 @@ describe('roomReducer', () => {
       const action: RoomAction = {
         type: 'revealed',
         participants: [
-          { connectionId: 'conn-host', userName: 'Host', vote: '5' },
+          { connectionId: 'conn-creator', userName: 'Creator', vote: '5' },
         ],
         average: 5,
       };
@@ -159,14 +158,14 @@ describe('roomReducer', () => {
       // Given
       const state = createInitialState({
         participants: new Map([
-          ['conn-host', { connectionId: 'conn-host', userName: 'Host', hasVoted: true, vote: null }],
+          ['conn-creator', { connectionId: 'conn-creator', userName: 'Creator', hasVoted: true, vote: null }],
           ['conn-alice', { connectionId: 'conn-alice', userName: 'Alice', hasVoted: true, vote: null }],
         ]),
       });
       const action: RoomAction = {
         type: 'revealed',
         participants: [
-          { connectionId: 'conn-host', userName: 'Host', vote: '5' },
+          { connectionId: 'conn-creator', userName: 'Creator', vote: '5' },
           { connectionId: 'conn-alice', userName: 'Alice', vote: '8' },
         ],
         average: 6.5,
@@ -176,7 +175,7 @@ describe('roomReducer', () => {
       const next = roomReducer(state, action);
 
       // Then
-      expect(next.participants.get('conn-host')?.vote).toBe('5');
+      expect(next.participants.get('conn-creator')?.vote).toBe('5');
       expect(next.participants.get('conn-alice')?.vote).toBe('8');
     });
 
@@ -186,7 +185,7 @@ describe('roomReducer', () => {
       const action: RoomAction = {
         type: 'revealed',
         participants: [
-          { connectionId: 'conn-host', userName: 'Host', vote: '5' },
+          { connectionId: 'conn-creator', userName: 'Creator', vote: '5' },
         ],
         average: 5,
       };
@@ -204,7 +203,7 @@ describe('roomReducer', () => {
       const action: RoomAction = {
         type: 'revealed',
         participants: [
-          { connectionId: 'conn-host', userName: 'Host', vote: '?' },
+          { connectionId: 'conn-creator', userName: 'Creator', vote: '?' },
         ],
         average: null,
       };
@@ -235,7 +234,7 @@ describe('roomReducer', () => {
       const state = createInitialState({
         status: 'revealed',
         participants: new Map([
-          ['conn-host', { connectionId: 'conn-host', userName: 'Host', hasVoted: true, vote: '5' }],
+          ['conn-creator', { connectionId: 'conn-creator', userName: 'Creator', hasVoted: true, vote: '5' }],
           ['conn-alice', { connectionId: 'conn-alice', userName: 'Alice', hasVoted: true, vote: '8' }],
         ]),
       });
@@ -268,7 +267,7 @@ describe('roomReducer', () => {
       const state = createInitialState({
         status: 'revealed',
         participants: new Map([
-          ['conn-host', { connectionId: 'conn-host', userName: 'Host', hasVoted: true, vote: '5' }],
+          ['conn-creator', { connectionId: 'conn-creator', userName: 'Creator', hasVoted: true, vote: '5' }],
           ['conn-alice', { connectionId: 'conn-alice', userName: 'Alice', hasVoted: true, vote: '8' }],
         ]),
       });
@@ -279,7 +278,7 @@ describe('roomReducer', () => {
 
       // Then
       expect(next.participants.size).toBe(2);
-      expect(next.participants.has('conn-host')).toBe(true);
+      expect(next.participants.has('conn-creator')).toBe(true);
       expect(next.participants.has('conn-alice')).toBe(true);
     });
   });
@@ -298,6 +297,16 @@ describe('roomReducer', () => {
 
       // Then
       expect(next).toEqual(state);
+    });
+  });
+
+  describe('host concept removal', () => {
+    it('should not have isHost in RoomState', () => {
+      // Given
+      const state = createInitialState();
+
+      // Then
+      expect(state).not.toHaveProperty('isHost');
     });
   });
 });

--- a/packages/frontend/src/features/room/components/room-view.tsx
+++ b/packages/frontend/src/features/room/components/room-view.tsx
@@ -38,7 +38,6 @@ function viewReducer(state: RoomState, action: ViewAction): RoomState {
       participants,
       myConnectionId: action.you.connectionId,
       myUserName: action.you.userName,
-      isHost: action.you.isHost,
       average: null,
     };
   }
@@ -66,7 +65,6 @@ function viewReducer(state: RoomState, action: ViewAction): RoomState {
       participants,
       myConnectionId: action.you.connectionId,
       myUserName: action.you.userName,
-      isHost: action.you.isHost,
       average: null,
     };
   }
@@ -80,7 +78,6 @@ function createInitialState(roomId: string): RoomState {
     participants: new Map<string, ParticipantState>(),
     myConnectionId: '',
     myUserName: '',
-    isHost: false,
     average: null,
   };
 }

--- a/packages/frontend/src/features/room/room-reducer.ts
+++ b/packages/frontend/src/features/room/room-reducer.ts
@@ -13,7 +13,6 @@ export interface RoomState {
   participants: Map<string, ParticipantState>;
   myConnectionId: string;
   myUserName: string;
-  isHost: boolean;
   average: number | null;
 }
 

--- a/packages/frontend/src/shared/lib/types.ts
+++ b/packages/frontend/src/shared/lib/types.ts
@@ -15,7 +15,6 @@ export interface RevealedParticipant {
 export interface YouInfo {
   connectionId: string;
   userName: string;
-  isHost: boolean;
 }
 
 export type ClientMessage =


### PR DESCRIPTION
## Summary

## 概要

reveal / reset は全員が実行できる方針とするため、`hostConnectionId` の概念を削除する。

## 対象箇所

### バックエンド
- `types.ts`: `Room` インターフェースから `hostConnectionId` を削除
- `createRoom.ts`: ルーム作成時に `hostConnectionId` をセットしている箇所を削除
- `joinRoom.ts`: `roomJoined` メッセージの `you.isHost` を削除

### フロントエンド
- `shared/lib/types.ts`: `YouInfo` から `isHost` を削除、`ServerMessage` の関連フィールドも整理
- `room-reducer.ts`: `RoomState` から `isHost` を削除
- `room-view.tsx`: `isHost` 関連の状態管理を削除

## 背景

- プランニングポーカーは全員で合意して進めるものなので、ホストだけが操作できる必要がない
- 現状フロントエンドでは既に全員に HostControls を表示しており、バックエンドにも権限チェックがない
- 不要な概念を残しておくとコードの理解を妨げるため、削除してシンプルにする

## Execution Report

Piece `default` completed successfully.

Closes #11